### PR TITLE
[usulan] tambah fuzzy search produk toleran typo dan tanpa spasi

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Models\Product;
 use App\Services\ProductService;
 
 class ProductController extends Controller
@@ -19,21 +18,9 @@ class ProductController extends Controller
     {
         $search = trim((string) $request->query('search', ''));
 
-        $products = Product::query()
-            ->where('is_active', true)
-            ->when($search !== '', function ($query) use ($search) {
-                $query->where(function ($innerQuery) use ($search) {
-                    $innerQuery->where('name', 'like', '%' . $search . '%')
-                        ->orWhere('sku', 'like', '%' . $search . '%')
-                        ->orWhere('barcode', 'like', '%' . $search . '%');
-                });
-            })
-            ->orderBy('name')
-            ->get();
-
         return response()->json([
             'success' => true,
-            'data' => $products,
+            'data' => $this->productService->search($search),
         ]);
     }
 

--- a/app/Http/Controllers/StockAdjustmentController.php
+++ b/app/Http/Controllers/StockAdjustmentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Product;
+use App\Services\ProductService;
 use App\Services\StockAdjustmentService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -11,22 +12,14 @@ use Illuminate\View\View;
 
 class StockAdjustmentController extends Controller
 {
-    public function index(Request $request): View
+    public function index(Request $request, ProductService $productService): View
     {
         $search = trim((string) $request->query('search', ''));
 
-        $products = Product::query()
-            ->where('is_active', true)
-            ->when($search !== '', function ($query) use ($search) {
-                $query->where(function ($innerQuery) use ($search) {
-                    $innerQuery->where('name', 'like', "%{$search}%")
-                        ->orWhere('sku', 'like', "%{$search}%")
-                        ->orWhere('barcode', 'like', "%{$search}%");
-                });
-            })
-            ->orderBy('name')
-            ->paginate(15)
-            ->withQueryString();
+        $products = $productService->searchPaginated($search, 15, (int) $request->query('page', 1), [
+            'path' => $request->url(),
+            'query' => $request->query(),
+        ]);
 
         return view('stock-adjustments.index', compact('products', 'search'));
     }

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Models\Product;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 
 class ProductService
 {
@@ -11,5 +13,103 @@ class ProductService
         $product = Product::where('sku', $sku)->first();
 
         return $product;
+    }
+
+    /**
+     * Fuzzy search active products by name/description, tolerant to typos
+     * and missing spaces. SKU/barcode still use plain substring matching so
+     * exact barcode scans stay reliable.
+     */
+    public function search(string $query): Collection
+    {
+        $products = Product::where('is_active', true)->orderBy('name')->get();
+
+        $query = trim($query);
+
+        if ($query === '') {
+            return $products->values();
+        }
+
+        return $products->filter(fn (Product $product) => $this->matches($product, $query))->values();
+    }
+
+    public function searchPaginated(string $query, int $perPage, int $page, array $paginatorOptions = []): LengthAwarePaginator
+    {
+        $results = $this->search($query);
+        $page = max(1, $page);
+
+        return new LengthAwarePaginator(
+            $results->forPage($page, $perPage)->values(),
+            $results->count(),
+            $perPage,
+            $page,
+            $paginatorOptions
+        );
+    }
+
+    private function matches(Product $product, string $query): bool
+    {
+        if ($product->sku && stripos($product->sku, $query) !== false) {
+            return true;
+        }
+
+        if ($product->barcode && stripos($product->barcode, $query) !== false) {
+            return true;
+        }
+
+        $normalizedQuery = $this->normalize($query);
+
+        if ($this->fuzzyMatchesPhrase($normalizedQuery, $product->name)) {
+            return true;
+        }
+
+        return $product->description !== null
+            && $this->fuzzyMatchesPhrase($normalizedQuery, $product->description);
+    }
+
+    private function fuzzyMatchesPhrase(string $normalizedQuery, string $phrase): bool
+    {
+        $normalizedPhrase = $this->normalize($phrase);
+
+        if ($normalizedPhrase === '') {
+            return false;
+        }
+
+        if (str_contains($normalizedPhrase, $normalizedQuery) || str_contains($normalizedQuery, $normalizedPhrase)) {
+            return true;
+        }
+
+        foreach (preg_split('/\s+/', trim($phrase)) as $word) {
+            $normalizedWord = $this->normalize($word);
+
+            if ($normalizedWord !== '' && $this->fuzzyMatches($normalizedQuery, $normalizedWord)) {
+                return true;
+            }
+        }
+
+        return $this->fuzzyMatches($normalizedQuery, $normalizedPhrase);
+    }
+
+    private function fuzzyMatches(string $normalizedQuery, string $normalizedTarget): bool
+    {
+        if ($normalizedQuery === '' || $normalizedTarget === '') {
+            return false;
+        }
+
+        return levenshtein($normalizedQuery, $normalizedTarget) <= $this->threshold(strlen($normalizedQuery));
+    }
+
+    private function threshold(int $length): int
+    {
+        return match (true) {
+            $length <= 3 => 0,
+            $length <= 5 => 1,
+            default => 2,
+        };
+    }
+
+    private function normalize(string $value): string
+    {
+        return preg_replace('/[^a-z0-9]/', '', strtolower($value));
     }
 }


### PR DESCRIPTION
## Description
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0b0bc0f4-8591-414c-9488-618cd9ea029c" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1e59ba3e-e76b-4ad2-8b45-e87a8fc96365" />

menambahkan fitur fuzzy atau lebih toleran dari typo input pengguna di search engine dibagian pos dan dibagian stock-adjustments, jadi contohnya saat pengguna ingin mencari nama barang "Aqua 600ml" seperti menginputkan query "akua" akan tetap muncul barang yang dicari yaitu "Aqua 600ml", selain dibagian nama barang juga bisa diimplementasikan di jenis barang, contohnya saat pengguna ingin mencari jenis barang "Camilan ringan" seperti menginputkan query "cemilan ringan" akan tetap muncul barang yang dicari yaitu "Camilan ringan"
